### PR TITLE
Making GitHub to be primary issue tracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,6 +4,7 @@ use warnings;
 BEGIN {
     my @devmods = qw(
         Module::Install::AuthorTests
+        Module::Install::Bugtracker
         Module::Install::ReadmeFromPod
         Module::Install::Repository
     );
@@ -46,5 +47,7 @@ requires 'Mouse';
 
 author_tests 'xt';
 auto_set_repository;
+
+resources bugtracker => 'https://github.com/typester/GitDDL/issues';
 
 WriteAll;


### PR DESCRIPTION
Now there are open tickets at https://rt.cpan.org/Dist/Display.html?Status=Active&Queue=GitDDL, but there also are open tickets here at GitHub

This PR sets the warning message at rt.cpan.org, that will look something like:

![screen shot 2015-06-02 at 00 29 31](https://cloud.githubusercontent.com/assets/47263/7923748/8c789a80-08be-11e5-8ca8-735bfcd578cf.png)
