### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,6 +36,7 @@ readme_from 'lib/GitDDL.pm';
 
 test_requires 'Test::More' => '0.86';
 test_requires 'Test::Git';
+test_requires 'Test::Requires::Git' => '1.005';
 
 requires 'perl' => '5.008001';
 requires 'SQL::Translator' => '0.11016';

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 
 use File::Spec;
 use File::Path 'make_path';
@@ -12,7 +13,7 @@ if ($@) {
     plan skip_all => 'DBD::SQLite is required to run this test';
 }
 
-has_git;
+test_requires_git;
 
 use_ok 'GitDDL';
 

--- a/t/sql_filter.t
+++ b/t/sql_filter.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use Test::Git;
+use Test::Requires::Git;
 
 use File::Path 'make_path';
 use GitDDL;


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
