### PR TITLE
add sqlt_args option

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ test_requires 'Test::More' => '0.86';
 test_requires 'Test::Git';
 
 requires 'perl' => '5.008001';
-requires 'SQL::Translator' => '0.11016';
+requires 'SQL::Translator' => '1.64';
 requires 'DBI';
 requires 'Git::Repository';
 requires 'File::Path' =>'2.07';

--- a/lib/GitDDL.pm
+++ b/lib/GitDDL.pm
@@ -36,6 +36,11 @@ has sql_filter => (
     builder => '_build_sql_filter',
 );
 
+has sqlt_args => (
+    is      => 'rw',
+    default => sub { +{} },
+);
+
 has version_table => (
     is      => 'rw',
     default => 'git_ddl_version',
@@ -144,6 +149,7 @@ sub diff {
         output_db     => $db,
         source_schema => $source->schema,
         target_schema => $target->schema,
+        sqlt_args     => $self->sqlt_args,
     })->compute_differences->produce_diff_sql;
 
     # ignore first line


### PR DESCRIPTION
create table をする際のSQLを文にはテーブル名やカラム名にクオートされているのに対し、それ以外の操作（alter tableなど）のSQL文にはクオートがなされない状況となっていました。

SQL::Translator::Diff が create table のSQL文を生成する際は SQL::Translator->new を経由して生成するため、SQL::Translator のメンバ変数 quote_identifiers のデフォルト値 '0E0' が採用され、テーブル名、カラム名がクオートされます。

一方で、それ以外のSQL文を生成するときは、 SQL::Translator::Producer::(MySQLなど) のメソッドが直接実行されます。このとき、オプションとして SQL::Translator::Diff のメンバ変数 sqlt_args が渡されるのですが、このデフォルト値は空ハッシュリファレンスであり、 quote_identifiers の指定がなされないため、クオートがされない状況となっていました。

今回、create_table以外のalter文などで、テーブル名、カラム名をクオートしてSQL文を生成することが必要な事情が発生したため、本PRを作成しました。

GitDDLオブジェクトを生成する際、
```
GitDDL->new(
    sqlt_args => { quote_identifiers => 1 },
);
```
のように指定することで、生成するすべてのSQL文でテーブル名とカラム名をクオートできるようになります。